### PR TITLE
Add Python 3.13

### DIFF
--- a/.github/ISSUE_TEMPLATE/package.yml
+++ b/.github/ISSUE_TEMPLATE/package.yml
@@ -43,6 +43,7 @@ body:
       options:
         - label: Python 3.9
         - label: Python 3.11
+        - label: Python 3.13
     validations:
       required: true
   - type: input


### PR DESCRIPTION
piwheels is now providing 3.13 packages for Trixie, so this should also be an option in the template.